### PR TITLE
Fixed config of demo

### DIFF
--- a/demo/config/default.json
+++ b/demo/config/default.json
@@ -1,5 +1,5 @@
 {
-  "vectorTiles": {
+  "koopOutputVectorTiles": {
     "geojsonVT": {
       "maxZoom": 14,
       "tolerance": 3,


### PR DESCRIPTION
The config-file of the demo had an old plugin name, so only defaults where used. Config is now in place.